### PR TITLE
Refactor

### DIFF
--- a/sketches/Anstis.js
+++ b/sketches/Anstis.js
@@ -28,6 +28,7 @@ var sketch6 = function( p ) {
     function makeBars() {
       p.strokeCap(p.SQUARE);
       p.strokeWeight(15);
+      p.stroke(0);
       for(var i = 0; i < 20; i++) 
         p.line(10+i*30,495-100,10+i*30,5);
     }

--- a/sketches/Anstis.js
+++ b/sketches/Anstis.js
@@ -26,7 +26,7 @@ var sketch6 = function( p ) {
     }
 
     function makeBars() {
-      p.strokeCap('SQUARE');
+      p.strokeCap(p.SQUARE);
       p.strokeWeight(15);
       for(var i = 0; i < 20; i++) 
         p.line(10+i*30,495-100,10+i*30,5);

--- a/sketches/MotionBinding.js
+++ b/sketches/MotionBinding.js
@@ -16,7 +16,7 @@ var speed = [ (d-delta)/45.0, -(d-delta)/45.0 ];
     p.draw = function() {
       p.background(127);
       p.stroke(0,0,255);
-      p.strokeCap('SQUARE');
+      p.strokeCap(p.SQUARE);
       p.strokeWeight(6);
       makeLinesTypeOne( );
       makeLinesTypeTwo(  );

--- a/sketches/MotionBinding.js
+++ b/sketches/MotionBinding.js
@@ -1,3 +1,5 @@
+var sketch5 = function( p ) {
+  
 var d = 50.0*(1.4142135623730950488016887242097);
 var delta = 15;
 var lx = [400+delta, 500+delta, 300-d+delta, 400-d+delta, 300-d/2.0, 400-d/2.0, 400+d/2.0, 500+d/2.0];
@@ -5,7 +7,6 @@ var ly = [2.0*d-delta, 100+2.0*d-delta, 100+3.0*d-delta, 200+3.0*d-delta, 100+(3
 var limits = [ [400+delta, 400+d-delta ], [300-d+delta, 300-delta] ];
 var speed = [ (d-delta)/45.0, -(d-delta)/45.0 ];
 
-var sketch5 = function( p ) {
     p.setup = function() {
       var myCanvas = p.createCanvas(800, 500);
       myCanvas.parent( 'MotionBinding_id' );

--- a/sketches/Zollner.js
+++ b/sketches/Zollner.js
@@ -16,7 +16,7 @@ var sketch4 = function( p ) {
 
     function makeParallelLines( ) {
       p.strokeWeight(15);
-      p.strokeCap('SQUARE');
+    p.strokeCap(p.SQUARE); 
       var aux = 100;
       var x = [100-aux,200-aux];
       var y = [500, 600];

--- a/sketches/color_gradient.js
+++ b/sketches/color_gradient.js
@@ -14,8 +14,8 @@ var sketch3 = function(p) {
         p.createCanvas(w,h);
         p.smooth();
         p.noLoop();
-    };
-
+    }; 
+ 
     // adapted from: https://p5js.org/examples/color-linear-gradient.html
     // this function draws a left to right gradient interpolating the values between two colors (c1,c2)
     function setGradient(c1, c2) {
@@ -23,7 +23,7 @@ var sketch3 = function(p) {
         // Left to right gradient
         for (var i = 0; i <=  w; i++) {
             var inter = p.map(i, 0, w, 0, 1);
-            var c = p.lerpColor(c1, c2, inter);
+            var c = p.lerpColor(p.color(c1), p.color(c2), inter);
             p.stroke(c);
             p.line(i, 0, i, h);
         }

--- a/sketches/color_gradient.js
+++ b/sketches/color_gradient.js
@@ -1,8 +1,9 @@
 // Author: Jairo Suarez
 // February 16, 2017
-var c1,c2,c3,w,h;
 
 var sketch3 = function(p) {
+    var c1,c2,c3,w,h;
+    
     p.setup = function() {
         w = 440; // canvas width
         h = 320; // canvas height

--- a/sketches/ponzo.js
+++ b/sketches/ponzo.js
@@ -12,6 +12,7 @@ var sketch1 = function( p ) {
     p.setup = function() {
         p.createCanvas(550, 400);
         p.smooth();               // antialias lines
+        p.noLoop();
     };
 
     p.draw = function() {
@@ -21,11 +22,11 @@ var sketch1 = function( p ) {
         p.strokeWeight(0);
         
         p.fill(0);      // medium weight lines 
-
+ 
         // Vertical/diagonal black thick lines
         // downleft,upleft,upright, downright
-        p.quad(85,400,255,0,260,0,115,400,5);
-        p.quad(440,400,280,0,285,0,470,400,5);
+        p.quad(85,400,255,0,260,0,115,400);
+        p.quad(440,400,280,0,285,0,470,400);
 
         //style
         p.stroke(0);
@@ -61,15 +62,6 @@ var sketch1 = function( p ) {
 
         p.stroke(0);
         p.strokeWeight(5);       // medium weight lines 
-        
-        // red strips
-        if( p.mouseIsPressed){
-            p.fill("#FF0000");
-            p.strokeWeight(0); 
-
-            p.rect(198,0,3,400);
-            p.rect(343,0,3,400);
-        }
 
         // four white lines
         p.stroke(255);
@@ -82,6 +74,19 @@ var sketch1 = function( p ) {
         p.filter("blur",1);
 
     };
+
+    // red strips
+    p.mousePressed = function () {
+        p.fill("#FF0000");
+        p.strokeWeight(0);
+    
+        p.rect(198, 0, 3, 400);
+        p.rect(343, 0, 3, 400);
+    }
+    
+    p.mouseReleased = function () {
+        p.draw();
+    }
 };
 
 var myp5_1 = new p5(sketch1, 'ponzo_id');

--- a/sketches/rotateSquare.js
+++ b/sketches/rotateSquare.js
@@ -6,10 +6,10 @@
   *
 **/
 
-var angle = 0;
-var speed = 0.1;
-
 var sketch = function (p) {
+    var angle = 0;
+    var speed = 0.1;
+
     p.setup = function () {
         var myCanvas = p.createCanvas(600, 600);
     };


### PR DESCRIPTION
Commit _6652a7f_:
Declaring variables outside the sketchs can override the value of another one with the same name, this happened when _Rotate Square_, re-declares `speed` overriding the variable defined on _Motion Binding_ affecting the functionality of itself.

Commit _0c53fa6_:
When using the `p5.js` instead of the minified (`p5.min.js`), it shows this warning:

![image](https://user-images.githubusercontent.com/14846464/47670375-023fdc00-db7b-11e8-88e6-4ebc67139255.png)

In order to remove it, in every usage of `strokeCap()` I have changed from an String value to the respective _p5 constant_.

Commit _33551fe_: 

*Color gradient* was throwing error, expecting color primitives instead of Strings.
*Ponzo* removed 9th argument, quad expects only eight arguments, converted to use noLoop() and to display only if necessary
*Anstis* this illusion should show vertical lines, which weren't displayed due to the usage of `noStroke()` when drawing rects